### PR TITLE
Fix filter regression

### DIFF
--- a/DotNetKit.Wpf.AutoCompleteComboBox/DotNetKit.Wpf.AutoCompleteComboBox.csproj
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/DotNetKit.Wpf.AutoCompleteComboBox.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>DotNetKit</RootNamespace>
     <Description>Provides a lightweight combobox with filtering (auto-complete).</Description>
     <Copyright>Copyright (c) 2017 vain0</Copyright>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>vain0</Authors>
     <projectUrl>https://github.com/DotNetKit/DotNetKit.Wpf.AutoCompleteComboBox</projectUrl>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -50,14 +51,11 @@ namespace DotNetKit.Windows.Controls
             return d.Value ?? string.Empty;
         }
 
-        protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
+        protected override void OnItemsSourceChanged(IEnumerable oldValue, IEnumerable newValue)
         {
-            base.OnItemsChanged(e);
+            base.OnItemsSourceChanged(oldValue, newValue);
 
-            if (defaultItemsFilter == null)
-            {
-                defaultItemsFilter = Items.Filter;
-            }
+            defaultItemsFilter = newValue is ICollectionView cv ? cv.Filter : null;
         }
 
         #region Setting


### PR DESCRIPTION
My PR #10 introduce a regression.
I doesn't used the right handler to track ItemSource changes so the default items filter is initialized with the wrong value when no CollectionView are present.
I modified the code to use the right handler and correctly detect when a CollectionView is used and apply the filter only in this case.

Fix #11 