### PR TITLE
Fix null reference inside OnTextChanged timer

### DIFF
--- a/DotNetKit.Wpf.AutoCompleteComboBox/DotNetKit.Wpf.AutoCompleteComboBox.csproj
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/DotNetKit.Wpf.AutoCompleteComboBox.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>DotNetKit</RootNamespace>
     <Description>Provides a lightweight combobox with filtering (auto-complete).</Description>
     <Copyright>Copyright (c) 2017 vain0</Copyright>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Authors>vain0</Authors>
     <projectUrl>https://github.com/DotNetKit/DotNetKit.Wpf.AutoCompleteComboBox</projectUrl>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -184,7 +184,7 @@ namespace DotNetKit.Windows.Controls
 
                 var filter = GetFilter();
                 var maxCount = SettingOrDefault.MaxSuggestionCount;
-                var count = CountWithMax(ItemsSource.Cast<object>(), filter, maxCount);
+                var count = CountWithMax(ItemsSource?.Cast<object>() ?? Enumerable.Empty<object>(), filter, maxCount);
 
                 if (count > maxCount) return;
 


### PR DESCRIPTION
Today I got this stacktrace in my log :

```cs
at IEnumerable<TResult> System.Linq.Enumerable.Cast<TResult>(IEnumerable source)
at void DotNetKit.Windows.Controls.AutoCompleteComboBox.UpdateSuggestionList()
at object System.Windows.Threading.DispatcherOperation.InvokeDelegateCore()
at void System.Windows.Threading.DispatcherOperation.InvokeImpl()
```

I found that it's caused because my app load ItemSource asynchronously and if a user enter text before the data has been loaded, the ItemSource is null and it's cause this.
The application doesn't crash because this code is run by the dispatcher, but the control is now in some sort of bad state and remain empty even after the ItemSource is populated.