### PR TITLE
Fix filter affects bound source collection by adding a dedicated FilterCollection

### DIFF
--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml
@@ -8,7 +8,9 @@
     mc:Ignorable="d" 
     d:DesignWidth="300"
     d:DesignHeight="300"
+    x:Name="this"
     IsEditable="True"
     IsTextSearchEnabled="False"
     PreviewKeyDown="ComboBox_PreviewKeyDown"
+    ItemsSource="{Binding ElementName=this, Path=ItemsSource}"
     />

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml
@@ -12,5 +12,4 @@
     IsEditable="True"
     IsTextSearchEnabled="False"
     PreviewKeyDown="ComboBox_PreviewKeyDown"
-    ItemsSource="{Binding ElementName=this, Path=ItemsSource}"
     />

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml
@@ -8,7 +8,6 @@
     mc:Ignorable="d" 
     d:DesignWidth="300"
     d:DesignHeight="300"
-    x:Name="this"
     IsEditable="True"
     IsTextSearchEnabled="False"
     PreviewKeyDown="ComboBox_PreviewKeyDown"

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using DotNetKit.Misc.Disposables;
 using DotNetKit.Windows.Media;
@@ -51,7 +53,7 @@ namespace DotNetKit.Windows.Controls
         #region ItemsSource
         public static new readonly DependencyProperty ItemsSourceProperty =
             DependencyProperty.Register(nameof(ItemsSource), typeof(IEnumerable), typeof(AutoCompleteComboBox),
-                new PropertyMetadata(null));
+                new PropertyMetadata(null, ItemsSourcePropertyChanged));
         public new IEnumerable ItemsSource
         {
             get
@@ -61,6 +63,28 @@ namespace DotNetKit.Windows.Controls
             set
             {
                 SetValue(ItemsSourceProperty, value);
+            }
+        }
+
+        private static void ItemsSourcePropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dpcea)
+        {
+            if (dpcea.NewValue is ICollectionView cv)
+            {
+                //TODO: Not working yet
+                //CollectionViewSource newCollectionViewSource = new CollectionViewSource();
+                ////Binding sourceBinding = new Binding() { Source = cv };
+                ////BindingOperations.SetBinding(newCollectionViewSource, CollectionViewSource.SourceProperty, sourceBinding);
+                //newCollectionViewSource.Source = cv;
+                //((ComboBox)dependencyObject).ItemsSource = newCollectionViewSource.View;
+            }
+            else
+            {
+                IEnumerable newValue = dpcea.NewValue as IEnumerable;
+                CollectionViewSource newCollectionViewSource = new CollectionViewSource
+                {
+                    Source = newValue
+                };
+                ((ComboBox)dependencyObject).ItemsSource = newCollectionViewSource.View;
             }
         }
         #endregion ItemsSource

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.ComponentModel;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
@@ -21,8 +20,6 @@ namespace DotNetKit.Windows.Controls
         readonly SerialDisposable disposable = new SerialDisposable();
 
         TextBox editableTextBoxCache;
-
-        Predicate<object> defaultItemsFilter;
 
         public TextBox EditableTextBox
         {
@@ -51,12 +48,22 @@ namespace DotNetKit.Windows.Controls
             return d.Value ?? string.Empty;
         }
 
-        protected override void OnItemsSourceChanged(IEnumerable oldValue, IEnumerable newValue)
+        #region ItemsSource
+        public static new readonly DependencyProperty ItemsSourceProperty =
+            DependencyProperty.Register(nameof(ItemsSource), typeof(IEnumerable), typeof(AutoCompleteComboBox),
+                new PropertyMetadata(null));
+        public new IEnumerable ItemsSource
         {
-            base.OnItemsSourceChanged(oldValue, newValue);
-
-            defaultItemsFilter = newValue is ICollectionView cv ? cv.Filter : null;
+            get
+            {
+                return (IEnumerable)GetValue(ItemsSourceProperty);
+            }
+            set
+            {
+                SetValue(ItemsSourceProperty, value);
+            }
         }
+        #endregion ItemsSource
 
         #region Setting
         static readonly DependencyProperty settingProperty =
@@ -167,7 +174,7 @@ namespace DotNetKit.Windows.Controls
 
                 using (Items.DeferRefresh())
                 {
-                    Items.Filter = defaultItemsFilter;
+                    Items.Filter = null;
                 }
             }
             else if (SelectedItem != null && TextFromItem(SelectedItem) == text)
@@ -232,11 +239,7 @@ namespace DotNetKit.Windows.Controls
 
         Predicate<object> GetFilter()
         {
-            var filter = SettingOrDefault.GetFilter(Text, TextFromItem);
-
-            return defaultItemsFilter != null
-                ? i => defaultItemsFilter(i) && filter(i)
-                : filter;
+            return SettingOrDefault.GetFilter(Text, TextFromItem);
         }
 
         public AutoCompleteComboBox()

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -23,6 +23,8 @@ namespace DotNetKit.Windows.Controls
 
         TextBox editableTextBoxCache;
 
+        Predicate<object> defaultItemsFilter;
+
         public TextBox EditableTextBox
         {
             get
@@ -70,12 +72,8 @@ namespace DotNetKit.Windows.Controls
         {
             if (dpcea.NewValue is ICollectionView cv)
             {
-                //TODO: Not working yet
-                //CollectionViewSource newCollectionViewSource = new CollectionViewSource();
-                ////Binding sourceBinding = new Binding() { Source = cv };
-                ////BindingOperations.SetBinding(newCollectionViewSource, CollectionViewSource.SourceProperty, sourceBinding);
-                //newCollectionViewSource.Source = cv;
-                //((ComboBox)dependencyObject).ItemsSource = newCollectionViewSource.View;
+                ((AutoCompleteComboBox)dependencyObject).defaultItemsFilter = cv.Filter;
+                ((ComboBox)dependencyObject).ItemsSource = cv;
             }
             else
             {
@@ -198,7 +196,7 @@ namespace DotNetKit.Windows.Controls
 
                 using (Items.DeferRefresh())
                 {
-                    Items.Filter = null;
+                    Items.Filter = defaultItemsFilter;
                 }
             }
             else if (SelectedItem != null && TextFromItem(SelectedItem) == text)
@@ -263,7 +261,11 @@ namespace DotNetKit.Windows.Controls
 
         Predicate<object> GetFilter()
         {
-            return SettingOrDefault.GetFilter(Text, TextFromItem);
+            var filter = SettingOrDefault.GetFilter(Text, TextFromItem);
+
+            return defaultItemsFilter != null
+                ? i => defaultItemsFilter(i) && filter(i)
+                : filter;
         }
 
         public AutoCompleteComboBox()

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -77,6 +77,7 @@ namespace DotNetKit.Windows.Controls
             }
             else
             {
+                ((AutoCompleteComboBox)dependencyObject).defaultItemsFilter = null;
                 IEnumerable newValue = dpcea.NewValue as IEnumerable;
                 CollectionViewSource newCollectionViewSource = new CollectionViewSource
                 {


### PR DESCRIPTION
multiple ComboBoxes are affecting each other using the same source. This is because the same CollectionView is used under the hood:

<dotNetKitControls:AutoCompleteComboBox ItemsSource="{Binding Items}" SelectedItem="{Binding Item1}"/>
<dotNetKitControls:AutoCompleteComboBox ItemsSource="{Binding Items}" SelectedItem="{Binding Item2}"/>

![Buggy](https://user-images.githubusercontent.com/29866610/228671918-bb9ee380-7e85-4b4b-9a1b-6e465df6a722.gif)

The PR aims to fix this by overwriting the ItemsSource property to create dedicated CollectionViewSources per control.

![Fixed](https://user-images.githubusercontent.com/29866610/228672245-336691cf-493b-46c9-889d-b6723280f1ed.gif)

Since nesting CollectionViewSource is not possible, the behaviour remains the same using CollectionViewSource as ItemsSource.