### PR TITLE
Properly synchronize the current selected item - Improve and fix #28

### DIFF
--- a/DotNetKit.Wpf.AutoCompleteComboBox/DotNetKit.Wpf.AutoCompleteComboBox.csproj
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/DotNetKit.Wpf.AutoCompleteComboBox.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>DotNetKit</RootNamespace>
     <Description>Provides a lightweight combobox with filtering (auto-complete).</Description>
     <Copyright>Copyright (c) 2017 vain0</Copyright>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Authors>vain0</Authors>
     <projectUrl>https://github.com/DotNetKit/DotNetKit.Wpf.AutoCompleteComboBox</projectUrl>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>

--- a/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox/Windows/Controls/AutoCompleteComboBox.xaml.cs
@@ -71,7 +71,6 @@ namespace DotNetKit.Windows.Controls
         private static void ItemsSourcePropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dpcea)
         {
             var comboBox = (ComboBox)dependencyObject;
-            var previousSelectedItem = comboBox.SelectedItem;
 
             if (dpcea.NewValue is ICollectionView cv)
             {
@@ -81,20 +80,12 @@ namespace DotNetKit.Windows.Controls
             else
             {
                 ((AutoCompleteComboBox)dependencyObject).defaultItemsFilter = null;
-                IEnumerable newValue = dpcea.NewValue as IEnumerable;
                 CollectionViewSource newCollectionViewSource = new CollectionViewSource
                 {
-                    Source = newValue
+                    Source = dpcea.NewValue
                 };
+                newCollectionViewSource.View?.MoveCurrentToPosition(-1);
                 comboBox.ItemsSource = newCollectionViewSource.View;
-            }
-
-            comboBox.SelectedItem = previousSelectedItem;
-
-            // if ItemsSource doesn't contain previousSelectedItem
-            if (comboBox.SelectedItem != previousSelectedItem)
-            {
-                comboBox.SelectedItem = null;
             }
         }
         #endregion ItemsSource


### PR DESCRIPTION
The PR #28 caused a regression when using a CollectionView, when the CollectionView is bound the SelectionItem is reset.

There is two cases to consider :
- There is an existing CollectionView, in this case let's the CollectionView handle it like before.
- There is no CollectionView, so we create it, but after that, explicitly its position to -1, so no item is selected by default, this is for me the right approach to fix #27 with the benefit to not impact the existing CollectionView use case.